### PR TITLE
bugfix for seeding

### DIFF
--- a/lib/mongoid_auto_inc.rb
+++ b/lib/mongoid_auto_inc.rb
@@ -6,10 +6,8 @@ module MongoidAutoInc
   module ClassMethods
     def auto_increment(name, options={})
       field name, :type => Integer
-      
       seq_name = "#{self.name.downcase}_#{name}"
       @@incrementor = MongoidAutoInc::Incrementor.new(options) 
-      @@incrementor[seq_name].set(options[:seed]) if options[:seed].is_a? Integer
 
       before_create { self.send("#{name}=", @@incrementor[seq_name].inc) } 
     end

--- a/lib/mongoid_auto_inc/incrementor.rb
+++ b/lib/mongoid_auto_inc/incrementor.rb
@@ -3,10 +3,10 @@
 module MongoidAutoInc
   class Incrementor
     class Sequence
-      def initialize(sequence, collection_name)
+      def initialize(sequence, collection_name, seed)
         @sequence = sequence.to_s
         @collection = collection_name.to_s
-        exists? || create
+        exists? || create(seed)
       end
 
       def inc
@@ -49,16 +49,18 @@ module MongoidAutoInc
       end
     end
     
-    def initialize(options={})
+    def initialize(options=nil)
+      options ||= {}
       @collection = options[:collection] || "sequences"
+      @seed = options[:seed].to_i
     end
 
     def [](sequence)
-      Sequence.new(sequence, @collection)
+      Sequence.new(sequence, @collection, @seed)
     end
 
     def []=(sequence, number)
-      Sequence.new(sequence, @collection).set(number)
+      Sequence.new(sequence, @collection, @seed).set(number)
     end
   end
 end


### PR DESCRIPTION
The current implementation will reset the counter every time it's initialized, rather than just when empty.  Ran across this when I had an external rake task that would add records--each time I ran rake the sequence number was reset and duplicate numbers were being added.
