### PR TITLE
Don't auto increment when value is provided

### DIFF
--- a/lib/mongoid_auto_inc.rb
+++ b/lib/mongoid_auto_inc.rb
@@ -9,7 +9,7 @@ module MongoidAutoInc
       seq_name = "#{self.name.downcase}_#{name}"
       @@incrementor = MongoidAutoInc::Incrementor.new(options) 
 
-      before_create { self.send("#{name}=", @@incrementor[seq_name].inc) } 
+      before_create { self.send("#{name}=", @@incrementor[seq_name].inc) unless self[name.to_sym].present? }
     end
   end
 end

--- a/spec/mongoid_auto_inc_spec.rb
+++ b/spec/mongoid_auto_inc_spec.rb
@@ -34,6 +34,11 @@ describe MongoidAutoInc do
       DocumentA.create!
       DocumentA.create!.seq.should == 2
     end
+    
+    it "should not auto increment when value is provided" do
+      doc = DocumentA.create!(seq: 33)
+      doc.seq.should == 33
+    end
   end
 
   describe "auto increment with :collection option" do


### PR DESCRIPTION
It's helpful in situations where you are migrating data from a relational database and need to keep the current id's of any record.
